### PR TITLE
Handle TCP socket closing by remote server

### DIFF
--- a/mbed/adapters/socketio_mbed_os5.cpp
+++ b/mbed/adapters/socketio_mbed_os5.cpp
@@ -170,8 +170,12 @@ static int retrieve_data(SOCKET_IO_INSTANCE* socket_io_instance)
                 socket_io_instance->on_bytes_received(socket_io_instance->on_bytes_received_context, recv_bytes, received);
             }
         }
-        else if (received < 0)
+        else if (received == 0)
         {
+            // Connection closed by remote, prepare to close
+            socket_io_instance->io_state = IO_STATE_CLOSING;
+        }
+        else {
             if(received != NSAPI_ERROR_WOULD_BLOCK)     // NSAPI_ERROR_WOULD_BLOCK is not a real error but pending.
             {
                 indicate_error(socket_io_instance);


### PR DESCRIPTION
## Issue
When an application (e.g. mbed-os-example-azure) finishes, it performs SDK clean up by calling `IoTHubDeviceClient_Destroy`. The SDK sends a disconnection requests to the Azure server, which then replies to us with a FIN signal (i.e. preparing to close the socket, no more receive/write operations please).

However, our porting layer isn't able to handle this, and continues trying to receive (poll for) data after FIN.  This results in an error:
```
Error: Time:Wed Jul 29 14:19:38 2020 File:./mbed-azure-client/dependencies/c-utility/adapters/tlsio_mbedtls.c Func:tlsio_mbedtls_close Line:697 xio_close failed
Error: Time:Wed Jul 29 14:19:38 2020 File:./mbed-azure-client/mbed/adapters/socketio_mbed_os5.cpp Func:retrieve_data Line:178 Socketio_Failure: underlying IO error -3004.
```
(-3004 is the error we get when trying to receive data after the underlying LWIP stack has received FIN, as described above.)

## How to reproduce

The issue is reproducible on targets that report `Socket::recv` errors properly (e.g. K64F). Some other network drivers (e.g. the WiFi driver on DISCO_L475VG_IOT01A) simply don't report errors...

Fetch the development branch of [mbed-os-example-azure|https://github.com/ARMmbed/mbed-os-example-azure/tree/development], set `iothub_client_trace` to true and fill in credentials in `mbed_app.json` before building and running. To trigger the issue, send a cloud-to-device message on the Azure portal - only when a message is received, our example deinitialises (or you can modify the code to deinitialise without receiving a message...).

## Solution
According to the [API doc](https://os.mbed.com/docs/mbed-os/v6.2/mbed-os-api-doxy/class_socket.html#ae97ae191484f90fda5a013b40b4b3ac5) for `Socket::recv` in Mbed OS:

> Number of received bytes on success, negative, subclass-dependent error code on failure. If no data is available to be received and the peer has performed an orderly shutdown, recv() returns 0.

This is specified by [the POSIX standards](https://pubs.opengroup.org/onlinepubs/9699919799/functions/recv.html).

So, as soon as the socket _returns 0_ (instead of the number of bytes > 0, or pending data), we should prepare for the closure of the socket.

Now the example completes without issues on K64F.