### PR TITLE
Update azure-iot-sdk-c to LTS_07_2021_Ref01

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -70,6 +70,7 @@ dependencies/c-utility/adapters/tlsio_template.c
 dependencies/c-utility/adapters/tlsio_wolfssl.c
 dependencies/c-utility/adapters/uniqueid_linux.c
 dependencies/c-utility/adapters/uniqueid_win32.c
+dependencies/c-utility/adapters/uniqueid_azsphere.c
 dependencies/c-utility/adapters/x509_*
 dependencies/c-utility/archive/*
 dependencies/c-utility/inc/azure_c_shared_utility/*

--- a/azure-iot-sdk-c.lib
+++ b/azure-iot-sdk-c.lib
@@ -1,1 +1,1 @@
-https://github.com/Azure/azure-iot-sdk-c#2bff372a9b22b54d3d4bc9a3e74e349f68fcde46
+https://github.com/Azure/azure-iot-sdk-c#8372cc9c1cbf2752573964af3c0bdfba614186b6

--- a/copied/c-utility/azure_c_shared_utility/crt_abstractions.h
+++ b/copied/c-utility/azure_c_shared_utility/crt_abstractions.h
@@ -5,11 +5,13 @@
 #define CRT_ABSTRACTIONS_H
 
 #ifdef __cplusplus
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <cerrno>
 #include <cmath>
 #else // __cplusplus
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
@@ -95,6 +97,7 @@ long double strtold_s(const char* nptr, char** endPtr);
 MOCKABLE_FUNCTION(, int, mallocAndStrcpy_s, char**, destination, const char*, source);
 MOCKABLE_FUNCTION(, int, unsignedIntToString, char*, destination, size_t, destinationSize, unsigned int, value);
 MOCKABLE_FUNCTION(, int, size_tToString, char*, destination, size_t, destinationSize, size_t, value);
+MOCKABLE_FUNCTION(, int, uint64_tToString, char*, destination, size_t, destinationSize, uint64_t, value);
 
 /*following logic shall define the TOUPPER and ISDIGIT, we do that because the SDK is not happy with some Arduino implementation of it.*/
 #define TOUPPER(c)      ((((c)>='a') && ((c)<='z'))?(c)-'a'+'A':c)

--- a/copied/c-utility/azure_c_shared_utility/httpapi.h
+++ b/copied/c-utility/azure_c_shared_utility/httpapi.h
@@ -2,12 +2,25 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 /** @file httpapi.h
- *    @brief     This module implements the standard HTTP API used by the C IoT client
+ *    @deprecated Applications should not directly use this header file.  They should use httpapiex.h instead.
+ *
+ *    @brief   Deprecated module implements the standard HTTP API used by the C IoT client
  *             library.
  *
  *    @details For example, on the Windows platform the HTTP API code uses
  *             WinHTTP and for Linux it uses curl and so forth. HTTPAPI must support
  *             HTTPs (HTTP+SSL).
+ *    
+ *    @remarks This header file is deprecated in the sense that applications should not directly invoke it.  
+ *             It remains the contract that instantiations of the HTTP clients on various platforms
+ *             (e.g. curl and WinHTTP) are implemented to.
+ *
+ *             Applications should not directly invoke functions in this header because this layer does
+ *             not follow the standard allocation/copying rules of the rest of the SDK.  When passed
+ *             a memory buffer, this layer points directly to the memory and does not make a copy or use reference counting.
+ *             This means there can be a crash if the caller free()'s the data but this layer needs it.
+ *             The httpapiex.h layer follows the conventions throughout the rest of the SDK and is 
+ *             therefore safer and less likely to cause unexpected problems for callers.
  */
 
 #ifndef HTTPAPI_H
@@ -77,6 +90,8 @@ MU_DEFINE_ENUM(HTTPAPI_REQUEST_TYPE, HTTPAPI_REQUEST_TYPE_VALUES);
 #define MAX_PASSWORD_LEN        65
 
 /**
+ * @deprecated Applications should not directly invoke this function.  They should use httpapiex.h instead.
+ *
  * @brief    Global initialization for the HTTP API component.
  *
  *            Platform specific implementations are expected to initialize
@@ -87,10 +102,16 @@ MU_DEFINE_ENUM(HTTPAPI_REQUEST_TYPE, HTTPAPI_REQUEST_TYPE_VALUES);
  */
 MOCKABLE_FUNCTION(, HTTPAPI_RESULT, HTTPAPI_Init);
 
-/** @brief    Free resources allocated in ::HTTPAPI_Init. */
+/** @brief    Free resources allocated in ::HTTPAPI_Init. 
+  *
+  * @deprecated Applications should not directly invoke this function.  They should use httpapiex.h instead.
+  *
+*/
 MOCKABLE_FUNCTION(, void, HTTPAPI_Deinit);
 
 /**
+ * @deprecated Applications should not directly invoke this function.  They should use httpapiex.h instead.
+ *
  * @brief    Creates an HTTPS connection to the host specified by the @p
  *             hostName parameter.
  *
@@ -106,6 +127,9 @@ MOCKABLE_FUNCTION(, void, HTTPAPI_Deinit);
 MOCKABLE_FUNCTION(, HTTP_HANDLE, HTTPAPI_CreateConnection, const char*, hostName);
 
 /**
+ *
+ * @deprecated Applications should not directly invoke this function.  They should use httpapiex.h instead.
+ *
  * @brief    Closes a connection created with ::HTTPAPI_CreateConnection.
  *
  * @param    handle    The handle to the HTTP connection created via ::HTTPAPI_CreateConnection.
@@ -169,6 +193,8 @@ MOCKABLE_FUNCTION(, HTTPAPI_RESULT, HTTPAPI_ExecuteRequest, HTTP_HANDLE, handle,
                                              HTTP_HEADERS_HANDLE, responseHeadersHandle, BUFFER_HANDLE, responseContent);
 
 /**
+ * @deprecated Applications should not directly invoke this function.  They should use httpapiex.h instead.
+ *
  * @brief    Sets the option named @p optionName bearing the value
  *             @p value for the HTTP_HANDLE @p handle.
  *
@@ -184,6 +210,8 @@ MOCKABLE_FUNCTION(, HTTPAPI_RESULT, HTTPAPI_ExecuteRequest, HTTP_HANDLE, handle,
 MOCKABLE_FUNCTION(, HTTPAPI_RESULT, HTTPAPI_SetOption, HTTP_HANDLE, handle, const char*, optionName, const void*, value);
 
 /**
+ * @deprecated Applications should not directly invoke this function.  They should use httpapiex.h instead.
+ *
  * @brief    Clones the option named @p optionName bearing the value @p value
  *             into the pointer @p savedValue.
  *

--- a/copied/c-utility/azure_c_shared_utility/sastoken.h
+++ b/copied/c-utility/azure_c_shared_utility/sastoken.h
@@ -4,6 +4,8 @@
 #ifndef SASTOKEN_H
 #define SASTOKEN_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 #else
 #include <stdbool.h>
@@ -17,8 +19,8 @@ extern "C" {
 #endif
 
     MOCKABLE_FUNCTION(, bool, SASToken_Validate, STRING_HANDLE, sasToken);
-    MOCKABLE_FUNCTION(, STRING_HANDLE, SASToken_Create, STRING_HANDLE, key, STRING_HANDLE, scope, STRING_HANDLE, keyName, size_t, expiry);
-    MOCKABLE_FUNCTION(, STRING_HANDLE, SASToken_CreateString, const char*, key, const char*, scope, const char*, keyName, size_t, expiry);
+    MOCKABLE_FUNCTION(, STRING_HANDLE, SASToken_Create, STRING_HANDLE, key, STRING_HANDLE, scope, STRING_HANDLE, keyName, uint64_t, expiry);
+    MOCKABLE_FUNCTION(, STRING_HANDLE, SASToken_CreateString, const char*, key, const char*, scope, const char*, keyName, uint64_t, expiry);
 
 #ifdef __cplusplus
 }

--- a/copied/c-utility/azure_c_shared_utility/shared_util_options.h
+++ b/copied/c-utility/azure_c_shared_utility/shared_util_options.h
@@ -28,6 +28,15 @@ extern "C"
     // They instead should rely on the underlying client TLS stack and service to negotiate an appropriate cipher.
     static STATIC_VAR_UNUSED const char* const OPTION_OPENSSL_CIPHER_SUITE = "CipherSuite";
 
+    static STATIC_VAR_UNUSED const char* const OPTION_OPENSSL_ENGINE = "Engine";
+    static STATIC_VAR_UNUSED const char* const OPTION_OPENSSL_PRIVATE_KEY_TYPE = "x509PrivatekeyType";
+
+    typedef enum OPTION_OPENSSL_KEY_TYPE_TAG
+    {
+        KEY_TYPE_DEFAULT,
+        KEY_TYPE_ENGINE
+    } OPTION_OPENSSL_KEY_TYPE;
+
     static STATIC_VAR_UNUSED const char* const SU_OPTION_X509_CERT = "x509certificate";
     static STATIC_VAR_UNUSED const char* const SU_OPTION_X509_PRIVATE_KEY = "x509privatekey";
 
@@ -40,6 +49,7 @@ extern "C"
     static STATIC_VAR_UNUSED const char* const OPTION_CURL_FORBID_REUSE = "CURLOPT_FORBID_REUSE";
     static STATIC_VAR_UNUSED const char* const OPTION_CURL_VERBOSE = "CURLOPT_VERBOSE";
 
+    static STATIC_VAR_UNUSED const char* const OPTION_CURL_INTERFACE = "CURLOPT_INTERFACE";
     static STATIC_VAR_UNUSED const char* const OPTION_NET_INT_MAC_ADDRESS = "net_interface_mac_address";
 
     static STATIC_VAR_UNUSED const char* const OPTION_SET_TLS_RENEGOTIATION = "tls_renegotiation";

--- a/copied/c-utility/azure_c_shared_utility/string_utils.h
+++ b/copied/c-utility/azure_c_shared_utility/string_utils.h
@@ -49,7 +49,7 @@ printf("PartitionId = %" GUID_FORMAT "\n", GUID_VALUES(fabricDeployedStatefulSer
 PartitionId=316132b8-96a0-4bc7-aecc-a16e7c5a6bf6
 */
 #define GUID_FORMAT "8.8" PRIx32 "-%4.4" PRIx16 "-%4.4" PRIx16 "-%4.4" PRIx16 "-%12.12" PRIx64
-#define GUID_VALUES(guid) (guid).Data1, (guid).Data2, (guid).Data3, ((guid).Data4[0]<<8) + (guid).Data4[1], ((uint64_t)((guid).Data4[2])<<40) + ((uint64_t)((guid).Data4[3])<<32) + (((uint64_t)(guid).Data4[4])<<24) + ((guid).Data4[5]<<16) + ((guid).Data4[6]<<8) + ((guid).Data4[7])
+#define GUID_VALUES(guid) (guid).Data1, (guid).Data2, (guid).Data3, (unsigned int)((((uint64_t)(guid).Data4[0]))<<8) + (guid).Data4[1], (((uint64_t)((guid).Data4[2]))<<40) + (((uint64_t)((guid).Data4[3]))<<32) + (((uint64_t)((guid).Data4[4]))<<24) + (((uint64_t)((guid).Data4[5]))<<16) + (((uint64_t)((guid).Data4[6]))<<8) + ((guid).Data4[7])
 
 /*takes a FILETIME, returns a nice string representation of it*/
 char* FILETIME_toAsciiArray(const FILETIME* fileTime);

--- a/copied/c-utility/azure_c_shared_utility/tickcounter.h
+++ b/copied/c-utility/azure_c_shared_utility/tickcounter.h
@@ -17,12 +17,7 @@ extern "C"
 {
 #endif /* __cplusplus */
 
-#if defined(_WIN32) || defined(__MBED__)
     typedef uint_fast64_t tickcounter_ms_t; // Use 64-bit because of 32-bit is going to roll over back to zero after roughly 49.7 days that is not good for IoT devices which need keep running for months
-#else
-    typedef uint_fast32_t tickcounter_ms_t;
-#endif
-
     typedef struct TICK_COUNTER_INSTANCE_TAG *TICK_COUNTER_HANDLE;
 
     MOCKABLE_FUNCTION(, TICK_COUNTER_HANDLE, tickcounter_create);

--- a/copied/c-utility/azure_c_shared_utility/tlsio.h
+++ b/copied/c-utility/azure_c_shared_utility/tlsio.h
@@ -4,6 +4,7 @@
 #ifndef TLSIO_H
 #define TLSIO_H
 
+#include <stdbool.h>
 #include "xio.h"
 
 #ifdef __cplusplus
@@ -16,6 +17,7 @@ typedef struct TLSIO_CONFIG_TAG
     int port;
     const IO_INTERFACE_DESCRIPTION* underlying_io_interface;
     void* underlying_io_parameters;
+    bool invoke_on_send_complete_callback_for_fragments;
 } TLSIO_CONFIG;
 
 #ifdef __cplusplus

--- a/copied/c-utility/azure_c_shared_utility/tlsio_wolfssl.h
+++ b/copied/c-utility/azure_c_shared_utility/tlsio_wolfssl.h
@@ -18,6 +18,9 @@ extern "C" {
 
 extern const char* const OPTION_WOLFSSL_SET_DEVICE_ID;
 
+MOCKABLE_FUNCTION(, int, tlsio_wolfssl_init);
+MOCKABLE_FUNCTION(, void, tlsio_wolfssl_deinit);
+
 MOCKABLE_FUNCTION(, CONCRETE_IO_HANDLE, tlsio_wolfssl_create, void*, io_create_parameters);
 MOCKABLE_FUNCTION(, void, tlsio_wolfssl_destroy, CONCRETE_IO_HANDLE, tls_io);
 MOCKABLE_FUNCTION(, int, tlsio_wolfssl_open, CONCRETE_IO_HANDLE, tls_io, ON_IO_OPEN_COMPLETE, on_io_open_complete, void*, on_io_open_complete_context, ON_BYTES_RECEIVED, on_bytes_received, void*, on_bytes_received_context, ON_IO_ERROR, on_io_error, void*, on_io_error_context);

--- a/copied/c-utility/azure_c_shared_utility/x509_openssl.h
+++ b/copied/c-utility/azure_c_shared_utility/x509_openssl.h
@@ -5,6 +5,7 @@
 #define X509_OPENSSL_H
 
 #include "openssl/ssl.h"
+#include "azure_c_shared_utility/shared_util_options.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,7 +14,7 @@ extern "C" {
 #include "umock_c/umock_c_prod.h"
 
 MOCKABLE_FUNCTION(,int, x509_openssl_add_certificates, SSL_CTX*, ssl_ctx, const char*, certificates);
-MOCKABLE_FUNCTION(,int, x509_openssl_add_credentials, SSL_CTX*, ssl_ctx, const char*, x509certificate, const char*, x509privatekey);
+MOCKABLE_FUNCTION(,int, x509_openssl_add_credentials, SSL_CTX*, ssl_ctx, const char*, x509certificate, const char*, x509privatekey, OPTION_OPENSSL_KEY_TYPE, x509privatekeytype, ENGINE*, engine);
 
 #ifdef __cplusplus
 }

--- a/dependencies/azure-umqtt-c.lib
+++ b/dependencies/azure-umqtt-c.lib
@@ -1,1 +1,1 @@
-https://github.com/Azure/azure-umqtt-c#165f6f52f8b2aec54a28ea5ede41736589726cd0
+https://github.com/Azure/azure-umqtt-c#493fe3fe72171eda195b2cd0e1f9b117c5d39e96

--- a/dependencies/c-utility.lib
+++ b/dependencies/c-utility.lib
@@ -1,1 +1,1 @@
-https://github.com/Azure/azure-c-shared-utility#65c27eb4ab9a8bbe36b4d7c5a0e9ad305becb8b4
+https://github.com/Azure/azure-c-shared-utility#e4d74dce9af5e885f0f26b4f9d2f693b358b6455


### PR DESCRIPTION
This commit updates the azure-iot-sdk-c to the latest LTS_07_2021_Ref01 release. It also updates the related dependencies to the versions specified by the above release of the azure-iot-sdk-c.

Testing has shown this fixes ARMMbed/mbed-os-example-for-azure#33. The MQTT client code has been refactored heavily so this is expected.